### PR TITLE
Fixes issues deserializing Addon

### DIFF
--- a/swiggy_order_hooks/example/restdb_processor.py
+++ b/swiggy_order_hooks/example/restdb_processor.py
@@ -93,7 +93,7 @@ class RestDBOrderProcessor(AbstractOrderProcessor):
             item_obj = {
                 'item_name': i.name,
                 'item_id': i.item_id,
-                'item_addons': i.addons,
+                'item_addons': [asdict(adn) for adn in i.addons],
                 'item_price': i.total,
                 'item_quantity': i.quantity
             }

--- a/swiggy_order_hooks/model/__init__.py
+++ b/swiggy_order_hooks/model/__init__.py
@@ -1,4 +1,5 @@
-from .item import Item, Addon
+from .addon import Addon
+from .item import Item
 from .cart import Cart
 from .customer import Customer
 from .delivery_executive import DeliveryExecutive

--- a/swiggy_order_hooks/model/addon.py
+++ b/swiggy_order_hooks/model/addon.py
@@ -1,0 +1,12 @@
+from typing import Optional
+
+from dataclasses_json import dataclass_json
+from dataclasses import dataclass
+
+@dataclass_json
+@dataclass
+class Addon:
+        choice_id: Optional[str] = None
+        group_id: Optional[str] = None
+        name: Optional[str] = None
+        price: Optional[float] = None

--- a/swiggy_order_hooks/model/cart.py
+++ b/swiggy_order_hooks/model/cart.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 from typing import Optional, List
 
@@ -7,5 +7,5 @@ from .item import Item
 @dataclass_json
 @dataclass
 class Cart:
-    charges: Optional[dict] = dict
-    items: Optional[List[Item]] = list
+    charges: Optional[dict] = field(default_factory=dict)
+    items: Optional[List[Item]] = field(default_factory=list)

--- a/swiggy_order_hooks/model/item.py
+++ b/swiggy_order_hooks/model/item.py
@@ -1,16 +1,9 @@
 from typing import List, Optional
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 
-
-@dataclass
-@dataclass_json
-class Addon:
-    choice_id: Optional[str] = None
-    group_id: Optional[str] = None
-    name: Optional[str] = None
-    price: Optional[float] = 0
+from .addon import Addon
 
 @dataclass_json
 @dataclass
@@ -24,11 +17,11 @@ class Item:
     total: Optional[float] = 0
     category: Optional[str] = None
     sub_category: Optional[str] = None
-    charges: Optional[dict] = dict
-    addons: Optional[List[Addon]] = list
+    charges: Optional[dict] = field(default_factory=dict)
+    addons: Optional[List[Addon]] = field(default_factory=list)
     variants: Optional[str] = None
-    newAddons: Optional[List[Addon]] = list
-    newVariants: Optional[List] = list
+    newAddons: Optional[List[Addon]] = field(default_factory=list)
+    newVariants: Optional[List] = field(default_factory=list)
     is_oos: Optional[bool] = None 
     is_veg: Optional[str] = None
     reward_type: Optional[str] = None

--- a/swiggy_order_hooks/model/order.py
+++ b/swiggy_order_hooks/model/order.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 
 from .order_status import OrderStatus
@@ -25,8 +25,8 @@ class Order:
     restaurant_details: Optional[RestaurantDetails] = None
     cart: Optional[Cart] = None
     restaurant_taxation_type: Optional[str] = None
-    GST_details: Optional[dict] = dict
-    vendorData: Optional[dict] = dict
+    GST_details: Optional[dict] = field(default_factory=dict)
+    vendorData: Optional[dict] = field(default_factory=dict)
     gst: Optional[float] = None
     serviceCharge: Optional[float] = None
     spending: Optional[float] = None
@@ -36,9 +36,9 @@ class Order:
     restaurant_trade_discount: Optional[float] = 0.0
     total_restaurant_discount: Optional[float] = None
     type: Optional[str] = None
-    cafe_data: Optional[dict] = dict
+    cafe_data: Optional[dict] = field(default_factory=dict)
     is_assured: Optional[bool] = False
-    discount_descriptions: Optional[list] = list
+    discount_descriptions: Optional[list] = field(default_factory=list)
     order_expiry_time: Optional[str] = None
     final_gp_price: Optional[float] = None
     customer: Optional[Customer] = None

--- a/swiggy_order_hooks/model/restaurant_data.py
+++ b/swiggy_order_hooks/model/restaurant_data.py
@@ -1,6 +1,6 @@
 from typing import Optional, List, Dict
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 
 from .order import Order
@@ -15,8 +15,8 @@ class RestaurantData:
     isOpen: Optional[bool] = None
     lastCachePollTime: Optional[int] = None
     batches: Optional[Dict] = dict
-    lastOrderEventTimestamps: Optional[Dict] = dict 
+    lastOrderEventTimestamps: Optional[Dict] = field(default_factory=dict) 
     isServiceable: Optional[bool] = None
     stressInfo: Optional[dict] = None
-    updatedOrderIds: Optional[List[str]] = list
-    popOrders: Optional[List[str]] = list
+    updatedOrderIds: Optional[List[str]] = field(default_factory=list)
+    popOrders: Optional[List[str]] = field(default_factory=list)

--- a/swiggy_order_hooks/model/restaurant_details.py
+++ b/swiggy_order_hooks/model/restaurant_details.py
@@ -1,5 +1,5 @@
 from typing import List, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from dataclasses_json import dataclass_json
 
 @dataclass_json
@@ -7,4 +7,4 @@ from dataclasses_json import dataclass_json
 class RestaurantDetails:
     restaurant_lat: Optional[str] = None
     restaurant_lng: Optional[str] = None
-    categories: Optional[List[str]] = list 
+    categories: Optional[List[str]] = field(default_factory=list) 


### PR DESCRIPTION
Fixes https://github.com/skvrahul/SwiggyOrderHooks/issues/1

This was caused due to not using a default factory for Dataclasses. 
This threw errors while deserializing fields set with the defaults. 
